### PR TITLE
Update bloatwareapps-11.txt

### DIFF
--- a/collections/bloatwareapps-11.txt
+++ b/collections/bloatwareapps-11.txt
@@ -39,3 +39,10 @@ Microsoft.XboxApp
 Microsoft.XboxGameOverlay
 Microsoft.XboxGamingOverlay
 Microsoft.XboxSpeechToTextOverlay
+2FE3CB00.PICSART-PHOTOSTUDIO_crhqpqs3x1???
+Clipchamp.Clipchamp_yxz26nhyzhsrt
+AdobeSystemsIncorporated.AdobeLightroom_???
+NAVER.LINEwin8_8ptj331gd3tyt
+CorelCorporation.PaintShopPro_wbjqpk9xt5???
+5319275A.WhatsAppDesktop_cv1g1gvanyjgm
+FACEBOOK.317180B0BB486_8xx8rvfyw5nnt


### PR DESCRIPTION
Added PicsArt, Lightroom, PaintShop Pro, LINE, WhatsApp, Messenger, and ClipChamp to bloatware list.