### PR TITLE
Updated the icon font to Segoe Fluent Icons

### DIFF
--- a/src/TIW11/MainWindow.Designer.cs
+++ b/src/TIW11/MainWindow.Designer.cs
@@ -58,9 +58,10 @@ namespace ThisIsWin11
             this.pnlLeft.Controls.Add(this.btnSystem);
             this.pnlLeft.Dock = System.Windows.Forms.DockStyle.Left;
             this.pnlLeft.Location = new System.Drawing.Point(0, 0);
+            this.pnlLeft.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pnlLeft.Name = "pnlLeft";
-            this.pnlLeft.Padding = new System.Windows.Forms.Padding(0, 20, 0, 0);
-            this.pnlLeft.Size = new System.Drawing.Size(78, 770);
+            this.pnlLeft.Padding = new System.Windows.Forms.Padding(0, 25, 0, 0);
+            this.pnlLeft.Size = new System.Drawing.Size(98, 962);
             this.pnlLeft.TabIndex = 130;
             // 
             // btnExtensions
@@ -69,13 +70,13 @@ namespace ThisIsWin11
             this.btnExtensions.FlatAppearance.BorderColor = System.Drawing.Color.WhiteSmoke;
             this.btnExtensions.FlatAppearance.BorderSize = 0;
             this.btnExtensions.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnExtensions.Font = new System.Drawing.Font("Segoe MDL2 Assets", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnExtensions.Font = new System.Drawing.Font("Segoe Fluent Icons", 14.25F);
             this.btnExtensions.ForeColor = System.Drawing.Color.DimGray;
             this.btnExtensions.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnExtensions.Location = new System.Drawing.Point(3, 370);
-            this.btnExtensions.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.btnExtensions.Location = new System.Drawing.Point(4, 462);
+            this.btnExtensions.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnExtensions.Name = "btnExtensions";
-            this.btnExtensions.Size = new System.Drawing.Size(72, 61);
+            this.btnExtensions.Size = new System.Drawing.Size(90, 76);
             this.btnExtensions.TabIndex = 145;
             this.btnExtensions.Text = "...";
             this.btnExtensions.UseVisualStyleBackColor = false;
@@ -88,13 +89,13 @@ namespace ThisIsWin11
             this.btnHome.FlatAppearance.BorderColor = System.Drawing.Color.WhiteSmoke;
             this.btnHome.FlatAppearance.BorderSize = 0;
             this.btnHome.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnHome.Font = new System.Drawing.Font("Segoe MDL2 Assets", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnHome.Font = new System.Drawing.Font("Segoe Fluent Icons", 11.25F);
             this.btnHome.ForeColor = System.Drawing.Color.MediumVioletRed;
             this.btnHome.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnHome.Location = new System.Drawing.Point(3, 25);
-            this.btnHome.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.btnHome.Location = new System.Drawing.Point(4, 31);
+            this.btnHome.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnHome.Name = "btnHome";
-            this.btnHome.Size = new System.Drawing.Size(72, 61);
+            this.btnHome.Size = new System.Drawing.Size(90, 76);
             this.btnHome.TabIndex = 144;
             this.btnHome.Text = "Home";
             this.btnHome.UseVisualStyleBackColor = false;
@@ -108,13 +109,13 @@ namespace ThisIsWin11
             this.btnSettings.FlatAppearance.BorderColor = System.Drawing.Color.WhiteSmoke;
             this.btnSettings.FlatAppearance.BorderSize = 0;
             this.btnSettings.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnSettings.Font = new System.Drawing.Font("Segoe MDL2 Assets", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnSettings.Font = new System.Drawing.Font("Segoe Fluent Icons", 12F);
             this.btnSettings.ForeColor = System.Drawing.Color.DimGray;
             this.btnSettings.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnSettings.Location = new System.Drawing.Point(3, 686);
-            this.btnSettings.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.btnSettings.Location = new System.Drawing.Point(4, 858);
+            this.btnSettings.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnSettings.Name = "btnSettings";
-            this.btnSettings.Size = new System.Drawing.Size(72, 72);
+            this.btnSettings.Size = new System.Drawing.Size(90, 90);
             this.btnSettings.TabIndex = 143;
             this.btnSettings.Text = "Settings";
             this.btnSettings.UseVisualStyleBackColor = false;
@@ -127,13 +128,13 @@ namespace ThisIsWin11
             this.btnAutomate.FlatAppearance.BorderColor = System.Drawing.Color.WhiteSmoke;
             this.btnAutomate.FlatAppearance.BorderSize = 0;
             this.btnAutomate.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnAutomate.Font = new System.Drawing.Font("Segoe MDL2 Assets", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnAutomate.Font = new System.Drawing.Font("Segoe Fluent Icons", 11.25F);
             this.btnAutomate.ForeColor = System.Drawing.Color.DimGray;
             this.btnAutomate.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnAutomate.Location = new System.Drawing.Point(3, 301);
-            this.btnAutomate.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.btnAutomate.Location = new System.Drawing.Point(4, 376);
+            this.btnAutomate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnAutomate.Name = "btnAutomate";
-            this.btnAutomate.Size = new System.Drawing.Size(72, 61);
+            this.btnAutomate.Size = new System.Drawing.Size(90, 76);
             this.btnAutomate.TabIndex = 142;
             this.btnAutomate.Text = "Automate";
             this.btnAutomate.UseVisualStyleBackColor = false;
@@ -146,13 +147,13 @@ namespace ThisIsWin11
             this.btnPackages.FlatAppearance.BorderColor = System.Drawing.Color.WhiteSmoke;
             this.btnPackages.FlatAppearance.BorderSize = 0;
             this.btnPackages.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnPackages.Font = new System.Drawing.Font("Segoe MDL2 Assets", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnPackages.Font = new System.Drawing.Font("Segoe Fluent Icons", 11.25F);
             this.btnPackages.ForeColor = System.Drawing.Color.DimGray;
             this.btnPackages.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnPackages.Location = new System.Drawing.Point(3, 232);
-            this.btnPackages.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.btnPackages.Location = new System.Drawing.Point(4, 290);
+            this.btnPackages.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnPackages.Name = "btnPackages";
-            this.btnPackages.Size = new System.Drawing.Size(72, 61);
+            this.btnPackages.Size = new System.Drawing.Size(90, 76);
             this.btnPackages.TabIndex = 141;
             this.btnPackages.Text = "Packages";
             this.btnPackages.UseVisualStyleBackColor = false;
@@ -165,13 +166,13 @@ namespace ThisIsWin11
             this.btnApps.FlatAppearance.BorderColor = System.Drawing.Color.WhiteSmoke;
             this.btnApps.FlatAppearance.BorderSize = 0;
             this.btnApps.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnApps.Font = new System.Drawing.Font("Segoe MDL2 Assets", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnApps.Font = new System.Drawing.Font("Segoe Fluent Icons", 11.25F);
             this.btnApps.ForeColor = System.Drawing.Color.DimGray;
             this.btnApps.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnApps.Location = new System.Drawing.Point(3, 163);
-            this.btnApps.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.btnApps.Location = new System.Drawing.Point(4, 204);
+            this.btnApps.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnApps.Name = "btnApps";
-            this.btnApps.Size = new System.Drawing.Size(72, 61);
+            this.btnApps.Size = new System.Drawing.Size(90, 76);
             this.btnApps.TabIndex = 140;
             this.btnApps.Text = "Apps";
             this.btnApps.UseVisualStyleBackColor = false;
@@ -184,13 +185,13 @@ namespace ThisIsWin11
             this.btnSystem.FlatAppearance.BorderColor = System.Drawing.Color.WhiteSmoke;
             this.btnSystem.FlatAppearance.BorderSize = 0;
             this.btnSystem.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnSystem.Font = new System.Drawing.Font("Segoe MDL2 Assets", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnSystem.Font = new System.Drawing.Font("Segoe Fluent Icons", 11.25F);
             this.btnSystem.ForeColor = System.Drawing.Color.DimGray;
             this.btnSystem.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnSystem.Location = new System.Drawing.Point(3, 94);
-            this.btnSystem.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.btnSystem.Location = new System.Drawing.Point(4, 118);
+            this.btnSystem.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnSystem.Name = "btnSystem";
-            this.btnSystem.Size = new System.Drawing.Size(72, 61);
+            this.btnSystem.Size = new System.Drawing.Size(90, 76);
             this.btnSystem.TabIndex = 139;
             this.btnSystem.Text = "System";
             this.btnSystem.UseVisualStyleBackColor = false;
@@ -203,36 +204,39 @@ namespace ThisIsWin11
             this.pnlContainer.AutoSize = true;
             this.pnlContainer.BackColor = System.Drawing.Color.White;
             this.pnlContainer.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pnlContainer.Location = new System.Drawing.Point(78, 0);
+            this.pnlContainer.Location = new System.Drawing.Point(98, 0);
+            this.pnlContainer.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pnlContainer.Name = "pnlContainer";
-            this.pnlContainer.Size = new System.Drawing.Size(1088, 770);
+            this.pnlContainer.Size = new System.Drawing.Size(1360, 962);
             this.pnlContainer.TabIndex = 136;
             // 
             // menuMain
             // 
             this.menuMain.BackColor = System.Drawing.Color.WhiteSmoke;
             this.menuMain.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.menuMain.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menuMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuMainComponents});
             this.menuMain.Name = "menuMain";
             this.menuMain.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.menuMain.Size = new System.Drawing.Size(174, 34);
+            this.menuMain.Size = new System.Drawing.Size(201, 40);
             // 
             // menuMainComponents
             // 
             this.menuMainComponents.Name = "menuMainComponents";
-            this.menuMainComponents.Size = new System.Drawing.Size(173, 30);
+            this.menuMainComponents.Size = new System.Drawing.Size(200, 36);
             this.menuMainComponents.Text = "Extensions";
             // 
             // MainWindow
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.White;
-            this.ClientSize = new System.Drawing.Size(1166, 770);
+            this.ClientSize = new System.Drawing.Size(1458, 962);
             this.Controls.Add(this.pnlContainer);
             this.Controls.Add(this.pnlLeft);
-            this.MinimumSize = new System.Drawing.Size(1182, 809);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.MinimumSize = new System.Drawing.Size(1473, 999);
             this.Name = "MainWindow";
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/src/TIW11/Pages/AppsWindow.Designer.cs
+++ b/src/TIW11/Pages/AppsWindow.Designer.cs
@@ -44,8 +44,8 @@ namespace ThisIsWin11
             this.menuAppsInfo = new System.Windows.Forms.ToolStripMenuItem();
             this.pnlRight = new System.Windows.Forms.Panel();
             this.lblAppsBinCount = new System.Windows.Forms.Label();
-            this.lstUWPRemove = new System.Windows.Forms.ListBox();
             this.rtbPS = new System.Windows.Forms.RichTextBox();
+            this.lstUWPRemove = new System.Windows.Forms.ListBox();
             this.PnlMiddle = new System.Windows.Forms.Panel();
             this.lblModuleInfo = new System.Windows.Forms.LinkLabel();
             this.lblAppsHeader = new System.Windows.Forms.Label();
@@ -68,7 +68,7 @@ namespace ThisIsWin11
             // menuAppsExport
             // 
             menuAppsExport.Name = "menuAppsExport";
-            menuAppsExport.Size = new System.Drawing.Size(347, 30);
+            menuAppsExport.Size = new System.Drawing.Size(420, 36);
             menuAppsExport.Text = "Export bloatware in Recycle Bin";
             menuAppsExport.Click += new System.EventHandler(this.menuAppsExport_Click);
             // 
@@ -84,10 +84,10 @@ namespace ThisIsWin11
             this.checkAppsSystem.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.checkAppsSystem.Font = new System.Drawing.Font("Segoe UI Semilight", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.checkAppsSystem.ForeColor = System.Drawing.Color.Black;
-            this.checkAppsSystem.Location = new System.Drawing.Point(11, 728);
+            this.checkAppsSystem.Location = new System.Drawing.Point(14, 911);
             this.checkAppsSystem.Margin = new System.Windows.Forms.Padding(2);
             this.checkAppsSystem.Name = "checkAppsSystem";
-            this.checkAppsSystem.Size = new System.Drawing.Size(145, 31);
+            this.checkAppsSystem.Size = new System.Drawing.Size(176, 38);
             this.checkAppsSystem.TabIndex = 103;
             this.checkAppsSystem.Text = "Show system apps";
             this.checkAppsSystem.UseVisualStyleBackColor = false;
@@ -103,10 +103,10 @@ namespace ThisIsWin11
             this.btnRemoveUWP.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnRemoveUWP.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnRemoveUWP.ForeColor = System.Drawing.Color.Black;
-            this.btnRemoveUWP.Location = new System.Drawing.Point(18, 24);
+            this.btnRemoveUWP.Location = new System.Drawing.Point(22, 30);
             this.btnRemoveUWP.Margin = new System.Windows.Forms.Padding(2);
             this.btnRemoveUWP.Name = "btnRemoveUWP";
-            this.btnRemoveUWP.Size = new System.Drawing.Size(307, 32);
+            this.btnRemoveUWP.Size = new System.Drawing.Size(384, 40);
             this.btnRemoveUWP.TabIndex = 104;
             this.btnRemoveUWP.Text = "Empty Recycle Bin";
             this.btnRemoveUWP.UseVisualStyleBackColor = false;
@@ -122,9 +122,10 @@ namespace ThisIsWin11
             this.lblAppsInstalledCount.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblAppsInstalledCount.ForeColor = System.Drawing.Color.DimGray;
             this.lblAppsInstalledCount.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblAppsInstalledCount.Location = new System.Drawing.Point(13, 21);
+            this.lblAppsInstalledCount.Location = new System.Drawing.Point(16, 26);
+            this.lblAppsInstalledCount.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblAppsInstalledCount.Name = "lblAppsInstalledCount";
-            this.lblAppsInstalledCount.Size = new System.Drawing.Size(69, 32);
+            this.lblAppsInstalledCount.Size = new System.Drawing.Size(87, 41);
             this.lblAppsInstalledCount.TabIndex = 137;
             this.lblAppsInstalledCount.Text = "Apps";
             // 
@@ -135,10 +136,11 @@ namespace ThisIsWin11
             this.btnAppsMenu.FlatAppearance.BorderSize = 0;
             this.btnAppsMenu.FlatAppearance.MouseOverBackColor = System.Drawing.Color.LightGray;
             this.btnAppsMenu.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnAppsMenu.Font = new System.Drawing.Font("Segoe MDL2 Assets", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnAppsMenu.Location = new System.Drawing.Point(293, 0);
+            this.btnAppsMenu.Font = new System.Drawing.Font("Segoe Fluent Icons", 14.25F);
+            this.btnAppsMenu.Location = new System.Drawing.Point(366, 0);
+            this.btnAppsMenu.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnAppsMenu.Name = "btnAppsMenu";
-            this.btnAppsMenu.Size = new System.Drawing.Size(48, 51);
+            this.btnAppsMenu.Size = new System.Drawing.Size(60, 64);
             this.btnAppsMenu.TabIndex = 156;
             this.btnAppsMenu.UseVisualStyleBackColor = false;
             this.btnAppsMenu.Click += new System.EventHandler(this.btnAppsMenu_Click);
@@ -147,6 +149,7 @@ namespace ThisIsWin11
             // 
             this.menuApps.BackColor = System.Drawing.Color.WhiteSmoke;
             this.menuApps.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.menuApps.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menuApps.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuAppsImport,
             menuAppsExport,
@@ -157,27 +160,27 @@ namespace ThisIsWin11
             this.menuAppsInfo});
             this.menuApps.Name = "menuMain";
             this.menuApps.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.menuApps.Size = new System.Drawing.Size(348, 190);
+            this.menuApps.Size = new System.Drawing.Size(421, 226);
             this.menuApps.Text = "Info";
             // 
             // menuAppsImport
             // 
             this.menuAppsImport.Name = "menuAppsImport";
-            this.menuAppsImport.Size = new System.Drawing.Size(347, 30);
+            this.menuAppsImport.Size = new System.Drawing.Size(420, 36);
             this.menuAppsImport.Text = "Import bloatware list";
             this.menuAppsImport.Click += new System.EventHandler(this.menuAppsImport_Click);
             // 
             // menuAppsRefresh
             // 
             this.menuAppsRefresh.Name = "menuAppsRefresh";
-            this.menuAppsRefresh.Size = new System.Drawing.Size(347, 30);
+            this.menuAppsRefresh.Size = new System.Drawing.Size(420, 36);
             this.menuAppsRefresh.Text = "Refresh";
             this.menuAppsRefresh.Click += new System.EventHandler(this.menuAppsRefresh_Click);
             // 
             // menuAppsRemoveAll
             // 
             this.menuAppsRemoveAll.Name = "menuAppsRemoveAll";
-            this.menuAppsRemoveAll.Size = new System.Drawing.Size(347, 30);
+            this.menuAppsRemoveAll.Size = new System.Drawing.Size(420, 36);
             this.menuAppsRemoveAll.Text = "Uninstall all apps";
             this.menuAppsRemoveAll.Click += new System.EventHandler(this.menuAppsRemoveAll_Click);
             // 
@@ -185,19 +188,19 @@ namespace ThisIsWin11
             // 
             this.menuAppsPopOut.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.menuAppsPopOut.Name = "menuAppsPopOut";
-            this.menuAppsPopOut.Size = new System.Drawing.Size(347, 30);
+            this.menuAppsPopOut.Size = new System.Drawing.Size(420, 36);
             this.menuAppsPopOut.Text = "Pop-out-App";
             this.menuAppsPopOut.Click += new System.EventHandler(this.menuAppsPopOut_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(344, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(417, 6);
             // 
             // menuAppsInfo
             // 
             this.menuAppsInfo.Name = "menuAppsInfo";
-            this.menuAppsInfo.Size = new System.Drawing.Size(347, 30);
+            this.menuAppsInfo.Size = new System.Drawing.Size(420, 36);
             this.menuAppsInfo.Text = "Info";
             this.menuAppsInfo.Click += new System.EventHandler(this.menuAppsInfo_Click);
             // 
@@ -208,9 +211,10 @@ namespace ThisIsWin11
             this.pnlRight.Controls.Add(this.rtbPS);
             this.pnlRight.Controls.Add(this.lstUWPRemove);
             this.pnlRight.Dock = System.Windows.Forms.DockStyle.Right;
-            this.pnlRight.Location = new System.Drawing.Point(716, 0);
+            this.pnlRight.Location = new System.Drawing.Point(895, 0);
+            this.pnlRight.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pnlRight.Name = "pnlRight";
-            this.pnlRight.Size = new System.Drawing.Size(371, 770);
+            this.pnlRight.Size = new System.Drawing.Size(464, 962);
             this.pnlRight.TabIndex = 157;
             // 
             // lblAppsBinCount
@@ -222,29 +226,12 @@ namespace ThisIsWin11
             this.lblAppsBinCount.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblAppsBinCount.ForeColor = System.Drawing.Color.MediumVioletRed;
             this.lblAppsBinCount.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblAppsBinCount.Location = new System.Drawing.Point(21, 21);
+            this.lblAppsBinCount.Location = new System.Drawing.Point(26, 26);
+            this.lblAppsBinCount.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblAppsBinCount.Name = "lblAppsBinCount";
-            this.lblAppsBinCount.Size = new System.Drawing.Size(338, 32);
+            this.lblAppsBinCount.Size = new System.Drawing.Size(422, 40);
             this.lblAppsBinCount.TabIndex = 135;
             this.lblAppsBinCount.Text = "Recycle Bin";
-            // 
-            // lstUWPRemove
-            // 
-            this.lstUWPRemove.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.lstUWPRemove.BackColor = System.Drawing.Color.WhiteSmoke;
-            this.lstUWPRemove.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.lstUWPRemove.Font = new System.Drawing.Font("Segoe UI Semilight", 12F);
-            this.lstUWPRemove.FormattingEnabled = true;
-            this.lstUWPRemove.ItemHeight = 21;
-            this.lstUWPRemove.Location = new System.Drawing.Point(27, 110);
-            this.lstUWPRemove.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.lstUWPRemove.Name = "lstUWPRemove";
-            this.lstUWPRemove.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
-            this.lstUWPRemove.Size = new System.Drawing.Size(343, 630);
-            this.lstUWPRemove.Sorted = true;
-            this.lstUWPRemove.TabIndex = 136;
-            this.lstUWPRemove.Visible = false;
             // 
             // rtbPS
             // 
@@ -255,13 +242,32 @@ namespace ThisIsWin11
             this.rtbPS.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.rtbPS.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.rtbPS.HideSelection = false;
-            this.rtbPS.Location = new System.Drawing.Point(27, 110);
+            this.rtbPS.Location = new System.Drawing.Point(34, 138);
+            this.rtbPS.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.rtbPS.Name = "rtbPS";
             this.rtbPS.ReadOnly = true;
-            this.rtbPS.Size = new System.Drawing.Size(341, 636);
+            this.rtbPS.Size = new System.Drawing.Size(426, 795);
             this.rtbPS.TabIndex = 138;
             this.rtbPS.Text = "";
             this.rtbPS.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.rtbPS_LinkClicked);
+            // 
+            // lstUWPRemove
+            // 
+            this.lstUWPRemove.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lstUWPRemove.BackColor = System.Drawing.Color.WhiteSmoke;
+            this.lstUWPRemove.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.lstUWPRemove.Font = new System.Drawing.Font("Segoe UI Semilight", 12F);
+            this.lstUWPRemove.FormattingEnabled = true;
+            this.lstUWPRemove.ItemHeight = 28;
+            this.lstUWPRemove.Location = new System.Drawing.Point(34, 138);
+            this.lstUWPRemove.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.lstUWPRemove.Name = "lstUWPRemove";
+            this.lstUWPRemove.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
+            this.lstUWPRemove.Size = new System.Drawing.Size(429, 784);
+            this.lstUWPRemove.Sorted = true;
+            this.lstUWPRemove.TabIndex = 136;
+            this.lstUWPRemove.Visible = false;
             // 
             // PnlMiddle
             // 
@@ -275,9 +281,10 @@ namespace ThisIsWin11
             this.PnlMiddle.Controls.Add(this.btnRemove);
             this.PnlMiddle.Controls.Add(this.btnRemoveAll);
             this.PnlMiddle.Controls.Add(this.btnAppsMenu);
-            this.PnlMiddle.Location = new System.Drawing.Point(374, 3);
+            this.PnlMiddle.Location = new System.Drawing.Point(468, 4);
+            this.PnlMiddle.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.PnlMiddle.Name = "PnlMiddle";
-            this.PnlMiddle.Size = new System.Drawing.Size(342, 688);
+            this.PnlMiddle.Size = new System.Drawing.Size(428, 860);
             this.PnlMiddle.TabIndex = 158;
             // 
             // lblModuleInfo
@@ -288,9 +295,10 @@ namespace ThisIsWin11
             this.lblModuleInfo.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblModuleInfo.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lblModuleInfo.LinkColor = System.Drawing.Color.MediumVioletRed;
-            this.lblModuleInfo.Location = new System.Drawing.Point(15, 63);
+            this.lblModuleInfo.Location = new System.Drawing.Point(19, 79);
+            this.lblModuleInfo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblModuleInfo.Name = "lblModuleInfo";
-            this.lblModuleInfo.Size = new System.Drawing.Size(307, 17);
+            this.lblModuleInfo.Size = new System.Drawing.Size(384, 21);
             this.lblModuleInfo.TabIndex = 163;
             this.lblModuleInfo.TabStop = true;
             this.lblModuleInfo.Text = "Learn more about PumpedApp";
@@ -304,9 +312,10 @@ namespace ThisIsWin11
             this.lblAppsHeader.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblAppsHeader.ForeColor = System.Drawing.Color.Black;
             this.lblAppsHeader.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblAppsHeader.Location = new System.Drawing.Point(12, 21);
+            this.lblAppsHeader.Location = new System.Drawing.Point(15, 26);
+            this.lblAppsHeader.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblAppsHeader.Name = "lblAppsHeader";
-            this.lblAppsHeader.Size = new System.Drawing.Size(275, 32);
+            this.lblAppsHeader.Size = new System.Drawing.Size(344, 40);
             this.lblAppsHeader.TabIndex = 25;
             this.lblAppsHeader.Text = "PumpedApp";
             // 
@@ -320,10 +329,10 @@ namespace ThisIsWin11
             this.btnAddAll.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnAddAll.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F);
             this.btnAddAll.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnAddAll.Location = new System.Drawing.Point(18, 115);
-            this.btnAddAll.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.btnAddAll.Location = new System.Drawing.Point(22, 144);
+            this.btnAddAll.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnAddAll.Name = "btnAddAll";
-            this.btnAddAll.Size = new System.Drawing.Size(307, 32);
+            this.btnAddAll.Size = new System.Drawing.Size(384, 40);
             this.btnAddAll.TabIndex = 21;
             this.btnAddAll.Text = "Add all >>";
             this.btnAddAll.UseVisualStyleBackColor = false;
@@ -339,10 +348,10 @@ namespace ThisIsWin11
             this.btnAdd.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnAdd.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F);
             this.btnAdd.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnAdd.Location = new System.Drawing.Point(18, 155);
-            this.btnAdd.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.btnAdd.Location = new System.Drawing.Point(22, 194);
+            this.btnAdd.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnAdd.Name = "btnAdd";
-            this.btnAdd.Size = new System.Drawing.Size(307, 32);
+            this.btnAdd.Size = new System.Drawing.Size(384, 40);
             this.btnAdd.TabIndex = 16;
             this.btnAdd.Text = "Add selected >";
             this.btnAdd.UseVisualStyleBackColor = false;
@@ -358,10 +367,10 @@ namespace ThisIsWin11
             this.btnRemove.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnRemove.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F);
             this.btnRemove.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnRemove.Location = new System.Drawing.Point(18, 253);
-            this.btnRemove.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.btnRemove.Location = new System.Drawing.Point(22, 316);
+            this.btnRemove.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnRemove.Name = "btnRemove";
-            this.btnRemove.Size = new System.Drawing.Size(307, 32);
+            this.btnRemove.Size = new System.Drawing.Size(384, 40);
             this.btnRemove.TabIndex = 17;
             this.btnRemove.Text = "< Restore selected";
             this.btnRemove.UseVisualStyleBackColor = false;
@@ -377,10 +386,10 @@ namespace ThisIsWin11
             this.btnRemoveAll.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnRemoveAll.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F);
             this.btnRemoveAll.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnRemoveAll.Location = new System.Drawing.Point(18, 213);
-            this.btnRemoveAll.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.btnRemoveAll.Location = new System.Drawing.Point(22, 266);
+            this.btnRemoveAll.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnRemoveAll.Name = "btnRemoveAll";
-            this.btnRemoveAll.Size = new System.Drawing.Size(307, 32);
+            this.btnRemoveAll.Size = new System.Drawing.Size(384, 40);
             this.btnRemoveAll.TabIndex = 22;
             this.btnRemoveAll.Text = "<< Restore all";
             this.btnRemoveAll.UseVisualStyleBackColor = false;
@@ -395,8 +404,9 @@ namespace ThisIsWin11
             this.PnlLeft.Controls.Add(this.checkAppsSystem);
             this.PnlLeft.Dock = System.Windows.Forms.DockStyle.Left;
             this.PnlLeft.Location = new System.Drawing.Point(0, 0);
+            this.PnlLeft.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.PnlLeft.Name = "PnlLeft";
-            this.PnlLeft.Size = new System.Drawing.Size(371, 770);
+            this.PnlLeft.Size = new System.Drawing.Size(464, 962);
             this.PnlLeft.TabIndex = 159;
             // 
             // lstUWP
@@ -407,12 +417,12 @@ namespace ThisIsWin11
             this.lstUWP.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.lstUWP.Font = new System.Drawing.Font("Segoe UI Semilight", 12F);
             this.lstUWP.FormattingEnabled = true;
-            this.lstUWP.ItemHeight = 21;
-            this.lstUWP.Location = new System.Drawing.Point(17, 118);
-            this.lstUWP.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.lstUWP.ItemHeight = 28;
+            this.lstUWP.Location = new System.Drawing.Point(21, 148);
+            this.lstUWP.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.lstUWP.Name = "lstUWP";
             this.lstUWP.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
-            this.lstUWP.Size = new System.Drawing.Size(351, 609);
+            this.lstUWP.Size = new System.Drawing.Size(439, 756);
             this.lstUWP.Sorted = true;
             this.lstUWP.TabIndex = 138;
             // 
@@ -424,9 +434,10 @@ namespace ThisIsWin11
             this.LblLeftAppName.AutoSize = true;
             this.LblLeftAppName.Font = new System.Drawing.Font("Segoe UI Semilight", 8.25F);
             this.LblLeftAppName.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.LblLeftAppName.Location = new System.Drawing.Point(16, 101);
+            this.LblLeftAppName.Location = new System.Drawing.Point(20, 126);
+            this.LblLeftAppName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.LblLeftAppName.Name = "LblLeftAppName";
-            this.LblLeftAppName.Size = new System.Drawing.Size(36, 13);
+            this.LblLeftAppName.Size = new System.Drawing.Size(45, 19);
             this.LblLeftAppName.TabIndex = 26;
             this.LblLeftAppName.Text = "Name";
             // 
@@ -435,23 +446,25 @@ namespace ThisIsWin11
             this.pnlBottom.AutoScroll = true;
             this.pnlBottom.Controls.Add(this.btnRemoveUWP);
             this.pnlBottom.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.pnlBottom.Location = new System.Drawing.Point(371, 697);
+            this.pnlBottom.Location = new System.Drawing.Point(464, 871);
+            this.pnlBottom.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pnlBottom.Name = "pnlBottom";
-            this.pnlBottom.Size = new System.Drawing.Size(345, 73);
+            this.pnlBottom.Size = new System.Drawing.Size(431, 91);
             this.pnlBottom.TabIndex = 160;
             // 
             // AppsWindow
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoScroll = true;
             this.BackColor = System.Drawing.Color.White;
-            this.ClientSize = new System.Drawing.Size(1087, 770);
+            this.ClientSize = new System.Drawing.Size(1359, 962);
             this.Controls.Add(this.pnlBottom);
             this.Controls.Add(this.PnlLeft);
             this.Controls.Add(this.pnlRight);
             this.Controls.Add(this.PnlMiddle);
             this.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "AppsWindow";
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/src/TIW11/Pages/AutomateWindow.Designer.cs
+++ b/src/TIW11/Pages/AutomateWindow.Designer.cs
@@ -61,21 +61,21 @@ namespace ThisIsWin11
             // menuAutomateImport
             // 
             this.menuAutomateImport.Name = "menuAutomateImport";
-            this.menuAutomateImport.Size = new System.Drawing.Size(411, 30);
+            this.menuAutomateImport.Size = new System.Drawing.Size(502, 36);
             this.menuAutomateImport.Text = "Import";
             this.menuAutomateImport.Click += new System.EventHandler(this.menuAutomateImport_Click);
             // 
             // menuAutomateEdit
             // 
             this.menuAutomateEdit.Name = "menuAutomateEdit";
-            this.menuAutomateEdit.Size = new System.Drawing.Size(411, 30);
+            this.menuAutomateEdit.Size = new System.Drawing.Size(502, 36);
             this.menuAutomateEdit.Text = "Edit ";
             this.menuAutomateEdit.Click += new System.EventHandler(this.menuAutomateEdit_Click);
             // 
             // menuAutomateSave
             // 
             this.menuAutomateSave.Name = "menuAutomateSave";
-            this.menuAutomateSave.Size = new System.Drawing.Size(411, 30);
+            this.menuAutomateSave.Size = new System.Drawing.Size(502, 36);
             this.menuAutomateSave.Text = "Save current script as new preset script";
             this.menuAutomateSave.Click += new System.EventHandler(this.menuAutomateSave_Click);
             // 
@@ -83,6 +83,7 @@ namespace ThisIsWin11
             // 
             this.menuAutomate.BackColor = System.Drawing.Color.WhiteSmoke;
             this.menuAutomate.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.menuAutomate.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menuAutomate.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuAutomateImport,
             this.menuAutomateEdit,
@@ -93,12 +94,12 @@ namespace ThisIsWin11
             this.menuAutomateInfo});
             this.menuAutomate.Name = "menuMain";
             this.menuAutomate.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.menuAutomate.Size = new System.Drawing.Size(412, 190);
+            this.menuAutomate.Size = new System.Drawing.Size(503, 226);
             // 
             // menuAutomateApplied
             // 
             this.menuAutomateApplied.Name = "menuAutomateApplied";
-            this.menuAutomateApplied.Size = new System.Drawing.Size(411, 30);
+            this.menuAutomateApplied.Size = new System.Drawing.Size(502, 36);
             this.menuAutomateApplied.Text = "Show applied";
             this.menuAutomateApplied.Click += new System.EventHandler(this.menuAutomateApplied_Click);
             // 
@@ -106,19 +107,19 @@ namespace ThisIsWin11
             // 
             this.menuAutomatePopOut.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.menuAutomatePopOut.Name = "menuAutomatePopOut";
-            this.menuAutomatePopOut.Size = new System.Drawing.Size(411, 30);
+            this.menuAutomatePopOut.Size = new System.Drawing.Size(502, 36);
             this.menuAutomatePopOut.Text = "Pop-out-App";
             this.menuAutomatePopOut.Click += new System.EventHandler(this.menuAutomatePopOut_Click);
             // 
             // menuAutomateSeparator
             // 
             this.menuAutomateSeparator.Name = "menuAutomateSeparator";
-            this.menuAutomateSeparator.Size = new System.Drawing.Size(408, 6);
+            this.menuAutomateSeparator.Size = new System.Drawing.Size(499, 6);
             // 
             // menuAutomateInfo
             // 
             this.menuAutomateInfo.Name = "menuAutomateInfo";
-            this.menuAutomateInfo.Size = new System.Drawing.Size(411, 30);
+            this.menuAutomateInfo.Size = new System.Drawing.Size(502, 36);
             this.menuAutomateInfo.Text = "Info";
             this.menuAutomateInfo.Click += new System.EventHandler(this.menuAutomateInfo_Click);
             // 
@@ -129,8 +130,9 @@ namespace ThisIsWin11
             this.panel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.panel1.Dock = System.Windows.Forms.DockStyle.Left;
             this.panel1.Location = new System.Drawing.Point(0, 0);
+            this.panel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(0, 770);
+            this.panel1.Size = new System.Drawing.Size(0, 962);
             this.panel1.TabIndex = 146;
             // 
             // btnCancel
@@ -141,9 +143,10 @@ namespace ThisIsWin11
             this.btnCancel.FlatAppearance.BorderSize = 0;
             this.btnCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnCancel.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnCancel.Location = new System.Drawing.Point(251, 24);
+            this.btnCancel.Location = new System.Drawing.Point(314, 30);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(213, 30);
+            this.btnCancel.Size = new System.Drawing.Size(266, 38);
             this.btnCancel.TabIndex = 160;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = false;
@@ -160,9 +163,10 @@ namespace ThisIsWin11
             this.lblHeader.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblHeader.ForeColor = System.Drawing.Color.DimGray;
             this.lblHeader.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblHeader.Location = new System.Drawing.Point(24, 19);
+            this.lblHeader.Location = new System.Drawing.Point(30, 24);
+            this.lblHeader.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeader.Name = "lblHeader";
-            this.lblHeader.Size = new System.Drawing.Size(186, 32);
+            this.lblHeader.Size = new System.Drawing.Size(232, 41);
             this.lblHeader.TabIndex = 159;
             this.lblHeader.Text = "Automate tasks";
             // 
@@ -176,9 +180,10 @@ namespace ThisIsWin11
             this.lstPS.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lstPS.ForeColor = System.Drawing.Color.Black;
             this.lstPS.FormattingEnabled = true;
-            this.lstPS.Location = new System.Drawing.Point(24, 94);
+            this.lstPS.Location = new System.Drawing.Point(30, 118);
+            this.lstPS.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.lstPS.Name = "lstPS";
-            this.lstPS.Size = new System.Drawing.Size(685, 352);
+            this.lstPS.Size = new System.Drawing.Size(856, 432);
             this.lstPS.Sorted = true;
             this.lstPS.TabIndex = 157;
             this.lstPS.ThreeDCheckBoxes = true;
@@ -188,10 +193,11 @@ namespace ThisIsWin11
             // 
             this.progress.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progress.Location = new System.Drawing.Point(30, 78);
+            this.progress.Location = new System.Drawing.Point(38, 98);
+            this.progress.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.progress.MarqueeAnimationSpeed = 30;
             this.progress.Name = "progress";
-            this.progress.Size = new System.Drawing.Size(663, 5);
+            this.progress.Size = new System.Drawing.Size(829, 6);
             this.progress.TabIndex = 156;
             this.progress.Visible = false;
             // 
@@ -201,10 +207,11 @@ namespace ThisIsWin11
             this.btnAutomateMenu.BackColor = System.Drawing.Color.White;
             this.btnAutomateMenu.FlatAppearance.BorderSize = 0;
             this.btnAutomateMenu.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnAutomateMenu.Font = new System.Drawing.Font("Segoe MDL2 Assets", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnAutomateMenu.Location = new System.Drawing.Point(667, 0);
+            this.btnAutomateMenu.Font = new System.Drawing.Font("Segoe Fluent Icons", 14.25F);
+            this.btnAutomateMenu.Location = new System.Drawing.Point(834, 0);
+            this.btnAutomateMenu.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnAutomateMenu.Name = "btnAutomateMenu";
-            this.btnAutomateMenu.Size = new System.Drawing.Size(48, 51);
+            this.btnAutomateMenu.Size = new System.Drawing.Size(60, 64);
             this.btnAutomateMenu.TabIndex = 155;
             this.btnAutomateMenu.UseVisualStyleBackColor = false;
             this.btnAutomateMenu.Click += new System.EventHandler(this.btnAutomateMenu_Click);
@@ -218,9 +225,10 @@ namespace ThisIsWin11
             this.btnApply.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnApply.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnApply.ForeColor = System.Drawing.Color.Black;
-            this.btnApply.Location = new System.Drawing.Point(24, 24);
+            this.btnApply.Location = new System.Drawing.Point(30, 30);
+            this.btnApply.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnApply.Name = "btnApply";
-            this.btnApply.Size = new System.Drawing.Size(213, 30);
+            this.btnApply.Size = new System.Drawing.Size(266, 38);
             this.btnApply.TabIndex = 154;
             this.btnApply.Text = "Apply selected";
             this.btnApply.UseVisualStyleBackColor = false;
@@ -233,10 +241,11 @@ namespace ThisIsWin11
             this.rtbDesc.BackColor = System.Drawing.Color.White;
             this.rtbDesc.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.rtbDesc.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.rtbDesc.Location = new System.Drawing.Point(24, 500);
+            this.rtbDesc.Location = new System.Drawing.Point(30, 625);
+            this.rtbDesc.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.rtbDesc.Name = "rtbDesc";
             this.rtbDesc.ReadOnly = true;
-            this.rtbDesc.Size = new System.Drawing.Size(686, 180);
+            this.rtbDesc.Size = new System.Drawing.Size(858, 225);
             this.rtbDesc.TabIndex = 153;
             this.rtbDesc.Text = "";
             this.rtbDesc.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.rtbDesc_LinkClicked);
@@ -249,9 +258,10 @@ namespace ThisIsWin11
             this.pnlRight.Controls.Add(this.lblModuleName);
             this.pnlRight.Controls.Add(this.rtbPS);
             this.pnlRight.Dock = System.Windows.Forms.DockStyle.Right;
-            this.pnlRight.Location = new System.Drawing.Point(716, 0);
+            this.pnlRight.Location = new System.Drawing.Point(895, 0);
+            this.pnlRight.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pnlRight.Name = "pnlRight";
-            this.pnlRight.Size = new System.Drawing.Size(371, 770);
+            this.pnlRight.Size = new System.Drawing.Size(464, 962);
             this.pnlRight.TabIndex = 161;
             // 
             // lblModuleInfo
@@ -260,9 +270,10 @@ namespace ThisIsWin11
             this.lblModuleInfo.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblModuleInfo.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lblModuleInfo.LinkColor = System.Drawing.Color.MediumVioletRed;
-            this.lblModuleInfo.Location = new System.Drawing.Point(24, 59);
+            this.lblModuleInfo.Location = new System.Drawing.Point(30, 74);
+            this.lblModuleInfo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblModuleInfo.Name = "lblModuleInfo";
-            this.lblModuleInfo.Size = new System.Drawing.Size(320, 17);
+            this.lblModuleInfo.Size = new System.Drawing.Size(400, 21);
             this.lblModuleInfo.TabIndex = 160;
             this.lblModuleInfo.TabStop = true;
             this.lblModuleInfo.Text = "Learn more about PowerUI";
@@ -277,9 +288,10 @@ namespace ThisIsWin11
             this.btnAutomateOnTheFly.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnAutomateOnTheFly.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnAutomateOnTheFly.ForeColor = System.Drawing.Color.WhiteSmoke;
-            this.btnAutomateOnTheFly.Location = new System.Drawing.Point(27, 721);
+            this.btnAutomateOnTheFly.Location = new System.Drawing.Point(34, 901);
+            this.btnAutomateOnTheFly.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnAutomateOnTheFly.Name = "btnAutomateOnTheFly";
-            this.btnAutomateOnTheFly.Size = new System.Drawing.Size(213, 30);
+            this.btnAutomateOnTheFly.Size = new System.Drawing.Size(266, 38);
             this.btnAutomateOnTheFly.TabIndex = 155;
             this.btnAutomateOnTheFly.Text = "Run this code on-the-fly";
             this.btnAutomateOnTheFly.UseVisualStyleBackColor = false;
@@ -295,9 +307,10 @@ namespace ThisIsWin11
             this.lblModuleName.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblModuleName.ForeColor = System.Drawing.Color.Black;
             this.lblModuleName.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblModuleName.Location = new System.Drawing.Point(21, 21);
+            this.lblModuleName.Location = new System.Drawing.Point(26, 26);
+            this.lblModuleName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblModuleName.Name = "lblModuleName";
-            this.lblModuleName.Size = new System.Drawing.Size(323, 32);
+            this.lblModuleName.Size = new System.Drawing.Size(404, 40);
             this.lblModuleName.TabIndex = 135;
             this.lblModuleName.Text = "PowerUI";
             // 
@@ -310,9 +323,10 @@ namespace ThisIsWin11
             this.rtbPS.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.rtbPS.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.rtbPS.HideSelection = false;
-            this.rtbPS.Location = new System.Drawing.Point(27, 110);
+            this.rtbPS.Location = new System.Drawing.Point(34, 138);
+            this.rtbPS.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.rtbPS.Name = "rtbPS";
-            this.rtbPS.Size = new System.Drawing.Size(343, 580);
+            this.rtbPS.Size = new System.Drawing.Size(429, 725);
             this.rtbPS.TabIndex = 138;
             this.rtbPS.Text = "";
             this.rtbPS.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.rtbPS_LinkClicked);
@@ -328,9 +342,10 @@ namespace ThisIsWin11
             this.lnkSubHeader.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.lnkSubHeader.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkSubHeader.LinkColor = System.Drawing.Color.MediumVioletRed;
-            this.lnkSubHeader.Location = new System.Drawing.Point(28, 57);
+            this.lnkSubHeader.Location = new System.Drawing.Point(35, 71);
+            this.lnkSubHeader.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lnkSubHeader.Name = "lnkSubHeader";
-            this.lnkSubHeader.Size = new System.Drawing.Size(660, 18);
+            this.lnkSubHeader.Size = new System.Drawing.Size(825, 22);
             this.lnkSubHeader.TabIndex = 172;
             // 
             // pnlBottom
@@ -339,18 +354,19 @@ namespace ThisIsWin11
             this.pnlBottom.Controls.Add(this.btnCancel);
             this.pnlBottom.Controls.Add(this.btnApply);
             this.pnlBottom.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.pnlBottom.Location = new System.Drawing.Point(0, 697);
+            this.pnlBottom.Location = new System.Drawing.Point(0, 871);
+            this.pnlBottom.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pnlBottom.Name = "pnlBottom";
-            this.pnlBottom.Size = new System.Drawing.Size(716, 73);
+            this.pnlBottom.Size = new System.Drawing.Size(895, 91);
             this.pnlBottom.TabIndex = 173;
             // 
             // AutomateWindow
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoScroll = true;
             this.BackColor = System.Drawing.Color.White;
-            this.ClientSize = new System.Drawing.Size(1087, 770);
+            this.ClientSize = new System.Drawing.Size(1359, 962);
             this.Controls.Add(this.pnlBottom);
             this.Controls.Add(this.lnkSubHeader);
             this.Controls.Add(this.lblHeader);
@@ -361,6 +377,7 @@ namespace ThisIsWin11
             this.Controls.Add(this.panel1);
             this.Controls.Add(this.pnlRight);
             this.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "AutomateWindow";
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/src/TIW11/Pages/ExtensionsWindow.Designer.cs
+++ b/src/TIW11/Pages/ExtensionsWindow.Designer.cs
@@ -99,7 +99,8 @@ namespace ThisIsWin11
             this.DataGridViewPlugs.EditMode = System.Windows.Forms.DataGridViewEditMode.EditProgrammatically;
             this.DataGridViewPlugs.EnableHeadersVisualStyles = false;
             this.DataGridViewPlugs.GridColor = System.Drawing.Color.WhiteSmoke;
-            this.DataGridViewPlugs.Location = new System.Drawing.Point(24, 166);
+            this.DataGridViewPlugs.Location = new System.Drawing.Point(30, 208);
+            this.DataGridViewPlugs.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.DataGridViewPlugs.MultiSelect = false;
             this.DataGridViewPlugs.Name = "DataGridViewPlugs";
             this.DataGridViewPlugs.ReadOnly = true;
@@ -120,7 +121,7 @@ namespace ThisIsWin11
             this.DataGridViewPlugs.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.DataGridViewPlugs.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
             this.DataGridViewPlugs.ShowEditingIcon = false;
-            this.DataGridViewPlugs.Size = new System.Drawing.Size(1051, 502);
+            this.DataGridViewPlugs.Size = new System.Drawing.Size(1314, 628);
             this.DataGridViewPlugs.TabIndex = 141;
             this.DataGridViewPlugs.TabStop = false;
             this.DataGridViewPlugs.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.DataGridViewPlugs_CellContentClick);
@@ -142,22 +143,24 @@ namespace ThisIsWin11
             this.ColumnState.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
             this.ColumnState.ThreeState = true;
             this.ColumnState.TrueValue = "1";
-            this.ColumnState.Width = 71;
+            this.ColumnState.Width = 83;
             // 
             // ColumnName
             // 
             this.ColumnName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.ColumnName.DataPropertyName = "Name";
             this.ColumnName.HeaderText = "Name";
+            this.ColumnName.MinimumWidth = 6;
             this.ColumnName.Name = "ColumnName";
             this.ColumnName.ReadOnly = true;
-            this.ColumnName.Width = 68;
+            this.ColumnName.Width = 81;
             // 
             // ColumnDescription
             // 
             this.ColumnDescription.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.ColumnDescription.DataPropertyName = "Description";
             this.ColumnDescription.HeaderText = "Description";
+            this.ColumnDescription.MinimumWidth = 6;
             this.ColumnDescription.Name = "ColumnDescription";
             this.ColumnDescription.ReadOnly = true;
             // 
@@ -166,17 +169,19 @@ namespace ThisIsWin11
             this.ColumnAuthor.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.ColumnAuthor.DataPropertyName = "Author";
             this.ColumnAuthor.HeaderText = "Author";
+            this.ColumnAuthor.MinimumWidth = 6;
             this.ColumnAuthor.Name = "ColumnAuthor";
             this.ColumnAuthor.ReadOnly = true;
-            this.ColumnAuthor.Width = 75;
+            this.ColumnAuthor.Width = 88;
             // 
             // textPlugsSearch
             // 
             this.textPlugsSearch.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.textPlugsSearch.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textPlugsSearch.Location = new System.Drawing.Point(864, 125);
+            this.textPlugsSearch.Location = new System.Drawing.Point(1080, 156);
+            this.textPlugsSearch.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.textPlugsSearch.Name = "textPlugsSearch";
-            this.textPlugsSearch.Size = new System.Drawing.Size(211, 23);
+            this.textPlugsSearch.Size = new System.Drawing.Size(263, 27);
             this.textPlugsSearch.TabIndex = 142;
             this.textPlugsSearch.Text = "Search...";
             this.textPlugsSearch.Click += new System.EventHandler(this.textSearch_Click);
@@ -189,10 +194,11 @@ namespace ThisIsWin11
             this.btnPluginsMenu.FlatAppearance.BorderSize = 0;
             this.btnPluginsMenu.FlatAppearance.MouseOverBackColor = System.Drawing.Color.LightGray;
             this.btnPluginsMenu.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnPluginsMenu.Font = new System.Drawing.Font("Segoe MDL2 Assets", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnPluginsMenu.Location = new System.Drawing.Point(1037, 0);
+            this.btnPluginsMenu.Font = new System.Drawing.Font("Segoe Fluent Icons", 14.25F);
+            this.btnPluginsMenu.Location = new System.Drawing.Point(1296, 0);
+            this.btnPluginsMenu.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnPluginsMenu.Name = "btnPluginsMenu";
-            this.btnPluginsMenu.Size = new System.Drawing.Size(48, 51);
+            this.btnPluginsMenu.Size = new System.Drawing.Size(60, 64);
             this.btnPluginsMenu.TabIndex = 157;
             this.btnPluginsMenu.UseVisualStyleBackColor = false;
             this.btnPluginsMenu.Click += new System.EventHandler(this.btnPlugsMenu_Click);
@@ -208,8 +214,9 @@ namespace ThisIsWin11
             this.pnlTop.Controls.Add(this.btnPluginsMenu);
             this.pnlTop.Controls.Add(this.lblHeader);
             this.pnlTop.Location = new System.Drawing.Point(0, 0);
+            this.pnlTop.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pnlTop.Name = "pnlTop";
-            this.pnlTop.Size = new System.Drawing.Size(1088, 119);
+            this.pnlTop.Size = new System.Drawing.Size(1360, 149);
             this.pnlTop.TabIndex = 164;
             // 
             // lnkPlugsDir
@@ -218,9 +225,10 @@ namespace ThisIsWin11
             this.lnkPlugsDir.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lnkPlugsDir.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkPlugsDir.LinkColor = System.Drawing.Color.MediumVioletRed;
-            this.lnkPlugsDir.Location = new System.Drawing.Point(319, 94);
+            this.lnkPlugsDir.Location = new System.Drawing.Point(399, 118);
+            this.lnkPlugsDir.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lnkPlugsDir.Name = "lnkPlugsDir";
-            this.lnkPlugsDir.Size = new System.Drawing.Size(128, 17);
+            this.lnkPlugsDir.Size = new System.Drawing.Size(162, 23);
             this.lnkPlugsDir.TabIndex = 160;
             this.lnkPlugsDir.TabStop = true;
             this.lnkPlugsDir.Text = "Open Plugins folder";
@@ -232,9 +240,10 @@ namespace ThisIsWin11
             this.lnkSubHeader.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lnkSubHeader.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkSubHeader.LinkColor = System.Drawing.Color.MediumVioletRed;
-            this.lnkSubHeader.Location = new System.Drawing.Point(27, 94);
+            this.lnkSubHeader.Location = new System.Drawing.Point(34, 118);
+            this.lnkSubHeader.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lnkSubHeader.Name = "lnkSubHeader";
-            this.lnkSubHeader.Size = new System.Drawing.Size(272, 17);
+            this.lnkSubHeader.Size = new System.Drawing.Size(343, 23);
             this.lnkSubHeader.TabIndex = 159;
             this.lnkSubHeader.TabStop = true;
             this.lnkSubHeader.Text = "More information about the Plugins engine";
@@ -245,9 +254,10 @@ namespace ThisIsWin11
             this.lblSubHeader.AutoSize = true;
             this.lblSubHeader.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblSubHeader.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.lblSubHeader.Location = new System.Drawing.Point(27, 61);
+            this.lblSubHeader.Location = new System.Drawing.Point(34, 76);
+            this.lblSubHeader.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblSubHeader.Name = "lblSubHeader";
-            this.lblSubHeader.Size = new System.Drawing.Size(439, 20);
+            this.lblSubHeader.Size = new System.Drawing.Size(551, 25);
             this.lblSubHeader.TabIndex = 158;
             this.lblSubHeader.Text = "Create your own tweaks and extend the capabilities of ThisIsWin11.";
             // 
@@ -260,9 +270,10 @@ namespace ThisIsWin11
             this.lblHeader.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblHeader.ForeColor = System.Drawing.Color.Black;
             this.lblHeader.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblHeader.Location = new System.Drawing.Point(24, 19);
+            this.lblHeader.Location = new System.Drawing.Point(30, 24);
+            this.lblHeader.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeader.Name = "lblHeader";
-            this.lblHeader.Size = new System.Drawing.Size(129, 32);
+            this.lblHeader.Size = new System.Drawing.Size(164, 41);
             this.lblHeader.TabIndex = 135;
             this.lblHeader.Text = "Extensions";
             // 
@@ -273,9 +284,10 @@ namespace ThisIsWin11
             this.lnkPlugsAttribution.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lnkPlugsAttribution.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkPlugsAttribution.LinkColor = System.Drawing.Color.MediumVioletRed;
-            this.lnkPlugsAttribution.Location = new System.Drawing.Point(26, 702);
+            this.lnkPlugsAttribution.Location = new System.Drawing.Point(32, 878);
+            this.lnkPlugsAttribution.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lnkPlugsAttribution.Name = "lnkPlugsAttribution";
-            this.lnkPlugsAttribution.Size = new System.Drawing.Size(175, 17);
+            this.lnkPlugsAttribution.Size = new System.Drawing.Size(222, 23);
             this.lnkPlugsAttribution.TabIndex = 165;
             this.lnkPlugsAttribution.TabStop = true;
             this.lnkPlugsAttribution.Text = "Karlkoorna\'s Tweaky engine";
@@ -289,9 +301,10 @@ namespace ThisIsWin11
             this.lblPlugsAttribution.Font = new System.Drawing.Font("Segoe UI Semibold", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblPlugsAttribution.ForeColor = System.Drawing.Color.Black;
             this.lblPlugsAttribution.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblPlugsAttribution.Location = new System.Drawing.Point(26, 671);
+            this.lblPlugsAttribution.Location = new System.Drawing.Point(32, 839);
+            this.lblPlugsAttribution.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblPlugsAttribution.Name = "lblPlugsAttribution";
-            this.lblPlugsAttribution.Size = new System.Drawing.Size(91, 21);
+            this.lblPlugsAttribution.Size = new System.Drawing.Size(114, 26);
             this.lblPlugsAttribution.TabIndex = 166;
             this.lblPlugsAttribution.Text = "Attribution";
             // 
@@ -299,6 +312,7 @@ namespace ThisIsWin11
             // 
             this.menuPlugins.BackColor = System.Drawing.Color.WhiteSmoke;
             this.menuPlugins.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.menuPlugins.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menuPlugins.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuPlugsRefresh,
             this.menuPlugsPopOut,
@@ -306,12 +320,12 @@ namespace ThisIsWin11
             this.menuPlugsInfo});
             this.menuPlugins.Name = "menuMain";
             this.menuPlugins.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.menuPlugins.Size = new System.Drawing.Size(195, 100);
+            this.menuPlugins.Size = new System.Drawing.Size(228, 118);
             // 
             // menuPlugsRefresh
             // 
             this.menuPlugsRefresh.Name = "menuPlugsRefresh";
-            this.menuPlugsRefresh.Size = new System.Drawing.Size(194, 30);
+            this.menuPlugsRefresh.Size = new System.Drawing.Size(227, 36);
             this.menuPlugsRefresh.Text = "Refresh";
             this.menuPlugsRefresh.Click += new System.EventHandler(this.menuPlugsRefresh_Click);
             // 
@@ -319,28 +333,28 @@ namespace ThisIsWin11
             // 
             this.menuPlugsPopOut.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.menuPlugsPopOut.Name = "menuPlugsPopOut";
-            this.menuPlugsPopOut.Size = new System.Drawing.Size(194, 30);
+            this.menuPlugsPopOut.Size = new System.Drawing.Size(227, 36);
             this.menuPlugsPopOut.Text = "Pop-out-App";
             this.menuPlugsPopOut.Click += new System.EventHandler(this.menuPlugsPopOut_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(191, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(224, 6);
             // 
             // menuPlugsInfo
             // 
             this.menuPlugsInfo.Name = "menuPlugsInfo";
-            this.menuPlugsInfo.Size = new System.Drawing.Size(194, 30);
+            this.menuPlugsInfo.Size = new System.Drawing.Size(227, 36);
             this.menuPlugsInfo.Text = "Info";
             this.menuPlugsInfo.Click += new System.EventHandler(this.menuPluginsInfo_Click);
             // 
             // ExtensionsWindow
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.WhiteSmoke;
-            this.ClientSize = new System.Drawing.Size(1087, 770);
+            this.ClientSize = new System.Drawing.Size(1359, 962);
             this.Controls.Add(this.lblPlugsAttribution);
             this.Controls.Add(this.lnkPlugsAttribution);
             this.Controls.Add(this.textPlugsSearch);
@@ -348,6 +362,7 @@ namespace ThisIsWin11
             this.Controls.Add(this.pnlTop);
             this.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Location = new System.Drawing.Point(24, 19);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "ExtensionsWindow";
             this.ShowIcon = false;
             this.Text = "ThisIsWin11 Extensions";

--- a/src/TIW11/Pages/HomeWindow.Designer.cs
+++ b/src/TIW11/Pages/HomeWindow.Designer.cs
@@ -66,8 +66,9 @@ namespace ThisIsWin11
             this.pnlLeft.Controls.Add(this.pbView);
             this.pnlLeft.Dock = System.Windows.Forms.DockStyle.Left;
             this.pnlLeft.Location = new System.Drawing.Point(0, 0);
+            this.pnlLeft.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pnlLeft.Name = "pnlLeft";
-            this.pnlLeft.Size = new System.Drawing.Size(371, 770);
+            this.pnlLeft.Size = new System.Drawing.Size(464, 962);
             this.pnlLeft.TabIndex = 163;
             // 
             // cbTable
@@ -78,9 +79,10 @@ namespace ThisIsWin11
             this.cbTable.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cbTable.Font = new System.Drawing.Font("Segoe UI Semilight", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.cbTable.FormattingEnabled = true;
-            this.cbTable.Location = new System.Drawing.Point(238, 735);
+            this.cbTable.Location = new System.Drawing.Point(298, 919);
+            this.cbTable.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.cbTable.Name = "cbTable";
-            this.cbTable.Size = new System.Drawing.Size(121, 23);
+            this.cbTable.Size = new System.Drawing.Size(150, 28);
             this.cbTable.TabIndex = 135;
             this.cbTable.SelectedIndexChanged += new System.EventHandler(this.cbTable_SelectedIndexChanged);
             // 
@@ -90,10 +92,11 @@ namespace ThisIsWin11
             this.btnPresenterMenu.FlatAppearance.BorderSize = 0;
             this.btnPresenterMenu.FlatAppearance.MouseOverBackColor = System.Drawing.Color.HotPink;
             this.btnPresenterMenu.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnPresenterMenu.Font = new System.Drawing.Font("Segoe MDL2 Assets", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnPresenterMenu.Location = new System.Drawing.Point(322, 0);
+            this.btnPresenterMenu.Font = new System.Drawing.Font("Segoe Fluent Icons", 14.25F);
+            this.btnPresenterMenu.Location = new System.Drawing.Point(402, 0);
+            this.btnPresenterMenu.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnPresenterMenu.Name = "btnPresenterMenu";
-            this.btnPresenterMenu.Size = new System.Drawing.Size(48, 51);
+            this.btnPresenterMenu.Size = new System.Drawing.Size(60, 64);
             this.btnPresenterMenu.TabIndex = 136;
             this.btnPresenterMenu.UseVisualStyleBackColor = true;
             this.btnPresenterMenu.Click += new System.EventHandler(this.btnPresenterMenu_Click);
@@ -108,10 +111,10 @@ namespace ThisIsWin11
             this.btnConfigurator.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnConfigurator.ForeColor = System.Drawing.Color.Black;
             this.btnConfigurator.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnConfigurator.Location = new System.Drawing.Point(83, 206);
-            this.btnConfigurator.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.btnConfigurator.Location = new System.Drawing.Point(104, 258);
+            this.btnConfigurator.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnConfigurator.Name = "btnConfigurator";
-            this.btnConfigurator.Size = new System.Drawing.Size(181, 32);
+            this.btnConfigurator.Size = new System.Drawing.Size(226, 40);
             this.btnConfigurator.TabIndex = 137;
             this.btnConfigurator.Text = "Configure this page";
             this.btnConfigurator.UseVisualStyleBackColor = false;
@@ -127,9 +130,10 @@ namespace ThisIsWin11
             this.lblHeader.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblHeader.ForeColor = System.Drawing.Color.DimGray;
             this.lblHeader.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblHeader.Location = new System.Drawing.Point(24, 25);
+            this.lblHeader.Location = new System.Drawing.Point(30, 31);
+            this.lblHeader.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeader.Name = "lblHeader";
-            this.lblHeader.Size = new System.Drawing.Size(283, 35);
+            this.lblHeader.Size = new System.Drawing.Size(354, 44);
             this.lblHeader.TabIndex = 134;
             this.lblHeader.Text = "Hi";
             // 
@@ -143,10 +147,10 @@ namespace ThisIsWin11
             this.btnCustomizer.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnCustomizer.ForeColor = System.Drawing.Color.White;
             this.btnCustomizer.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnCustomizer.Location = new System.Drawing.Point(83, 166);
-            this.btnCustomizer.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.btnCustomizer.Location = new System.Drawing.Point(104, 208);
+            this.btnCustomizer.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnCustomizer.Name = "btnCustomizer";
-            this.btnCustomizer.Size = new System.Drawing.Size(181, 32);
+            this.btnCustomizer.Size = new System.Drawing.Size(226, 40);
             this.btnCustomizer.TabIndex = 138;
             this.btnCustomizer.Text = "Customize this page";
             this.btnCustomizer.UseVisualStyleBackColor = false;
@@ -166,9 +170,10 @@ namespace ThisIsWin11
             this.btnPresenter.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnPresenter.ForeColor = System.Drawing.Color.White;
             this.btnPresenter.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnPresenter.Location = new System.Drawing.Point(0, 250);
+            this.btnPresenter.Location = new System.Drawing.Point(0, 312);
+            this.btnPresenter.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnPresenter.Name = "btnPresenter";
-            this.btnPresenter.Size = new System.Drawing.Size(371, 32);
+            this.btnPresenter.Size = new System.Drawing.Size(464, 40);
             this.btnPresenter.TabIndex = 139;
             this.btnPresenter.Text = "Preview this page";
             this.btnPresenter.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -181,9 +186,10 @@ namespace ThisIsWin11
             this.pbView.ErrorImage = null;
             this.pbView.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.pbView.InitialImage = null;
-            this.pbView.Location = new System.Drawing.Point(0, 209);
+            this.pbView.Location = new System.Drawing.Point(0, 261);
+            this.pbView.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pbView.Name = "pbView";
-            this.pbView.Size = new System.Drawing.Size(371, 561);
+            this.pbView.Size = new System.Drawing.Size(464, 701);
             this.pbView.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.pbView.TabIndex = 127;
             this.pbView.TabStop = false;
@@ -198,9 +204,10 @@ namespace ThisIsWin11
             this.lblSubHeader.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblSubHeader.ForeColor = System.Drawing.Color.Black;
             this.lblSubHeader.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblSubHeader.Location = new System.Drawing.Point(24, 19);
+            this.lblSubHeader.Location = new System.Drawing.Point(30, 24);
+            this.lblSubHeader.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblSubHeader.Name = "lblSubHeader";
-            this.lblSubHeader.Size = new System.Drawing.Size(672, 32);
+            this.lblSubHeader.Size = new System.Drawing.Size(840, 40);
             this.lblSubHeader.TabIndex = 135;
             this.lblSubHeader.Text = "Meet Windows 11";
             // 
@@ -217,9 +224,10 @@ namespace ThisIsWin11
             this.pnlMiddle.Controls.Add(this.linkLabel1);
             this.pnlMiddle.Controls.Add(this.lblDesc);
             this.pnlMiddle.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pnlMiddle.Location = new System.Drawing.Point(371, 0);
+            this.pnlMiddle.Location = new System.Drawing.Point(464, 0);
+            this.pnlMiddle.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pnlMiddle.Name = "pnlMiddle";
-            this.pnlMiddle.Size = new System.Drawing.Size(716, 770);
+            this.pnlMiddle.Size = new System.Drawing.Size(895, 962);
             this.pnlMiddle.TabIndex = 164;
             // 
             // lnkSubHeader
@@ -231,9 +239,10 @@ namespace ThisIsWin11
             this.lnkSubHeader.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.lnkSubHeader.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkSubHeader.LinkColor = System.Drawing.Color.MediumVioletRed;
-            this.lnkSubHeader.Location = new System.Drawing.Point(24, 68);
+            this.lnkSubHeader.Location = new System.Drawing.Point(30, 85);
+            this.lnkSubHeader.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lnkSubHeader.Name = "lnkSubHeader";
-            this.lnkSubHeader.Size = new System.Drawing.Size(313, 18);
+            this.lnkSubHeader.Size = new System.Drawing.Size(391, 22);
             this.lnkSubHeader.TabIndex = 24;
             this.lnkSubHeader.TabStop = true;
             this.lnkSubHeader.Text = "Os";
@@ -245,10 +254,11 @@ namespace ThisIsWin11
             this.btnBack.BackColor = System.Drawing.Color.WhiteSmoke;
             this.btnBack.FlatAppearance.BorderSize = 0;
             this.btnBack.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnBack.Font = new System.Drawing.Font("Segoe MDL2 Assets", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnBack.Location = new System.Drawing.Point(590, 726);
+            this.btnBack.Font = new System.Drawing.Font("Segoe Fluent Icons", 12F);
+            this.btnBack.Location = new System.Drawing.Point(738, 908);
+            this.btnBack.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnBack.Name = "btnBack";
-            this.btnBack.Size = new System.Drawing.Size(50, 32);
+            this.btnBack.Size = new System.Drawing.Size(62, 40);
             this.btnBack.TabIndex = 136;
             this.btnBack.Text = "<";
             this.btnBack.UseVisualStyleBackColor = false;
@@ -260,11 +270,12 @@ namespace ThisIsWin11
             this.btnNext.BackColor = System.Drawing.Color.MediumVioletRed;
             this.btnNext.FlatAppearance.BorderSize = 0;
             this.btnNext.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnNext.Font = new System.Drawing.Font("Segoe MDL2 Assets", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnNext.Font = new System.Drawing.Font("Segoe Fluent Icons", 12F);
             this.btnNext.ForeColor = System.Drawing.Color.White;
-            this.btnNext.Location = new System.Drawing.Point(646, 726);
+            this.btnNext.Location = new System.Drawing.Point(808, 908);
+            this.btnNext.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnNext.Name = "btnNext";
-            this.btnNext.Size = new System.Drawing.Size(50, 32);
+            this.btnNext.Size = new System.Drawing.Size(62, 40);
             this.btnNext.TabIndex = 135;
             this.btnNext.Text = ">";
             this.btnNext.UseVisualStyleBackColor = false;
@@ -278,13 +289,13 @@ namespace ThisIsWin11
             this.btnHome.FlatAppearance.BorderColor = System.Drawing.Color.WhiteSmoke;
             this.btnHome.FlatAppearance.MouseOverBackColor = System.Drawing.Color.LightGray;
             this.btnHome.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnHome.Font = new System.Drawing.Font("Segoe MDL2 Assets", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnHome.Font = new System.Drawing.Font("Segoe Fluent Icons", 12F);
             this.btnHome.ForeColor = System.Drawing.Color.Black;
             this.btnHome.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.btnHome.Location = new System.Drawing.Point(534, 726);
-            this.btnHome.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.btnHome.Location = new System.Drawing.Point(668, 908);
+            this.btnHome.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnHome.Name = "btnHome";
-            this.btnHome.Size = new System.Drawing.Size(50, 32);
+            this.btnHome.Size = new System.Drawing.Size(62, 40);
             this.btnHome.TabIndex = 128;
             this.btnHome.UseVisualStyleBackColor = false;
             this.btnHome.Click += new System.EventHandler(this.btnHome_Click);
@@ -299,9 +310,10 @@ namespace ThisIsWin11
             this.linkLabel1.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.linkLabel1.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.linkLabel1.LinkColor = System.Drawing.Color.Black;
-            this.linkLabel1.Location = new System.Drawing.Point(13, 68);
+            this.linkLabel1.Location = new System.Drawing.Point(16, 85);
+            this.linkLabel1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.linkLabel1.Name = "linkLabel1";
-            this.linkLabel1.Size = new System.Drawing.Size(565, 18);
+            this.linkLabel1.Size = new System.Drawing.Size(706, 22);
             this.linkLabel1.TabIndex = 24;
             // 
             // lblDesc
@@ -312,9 +324,10 @@ namespace ThisIsWin11
             this.lblDesc.AutoEllipsis = true;
             this.lblDesc.Font = new System.Drawing.Font("Segoe UI", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblDesc.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            this.lblDesc.Location = new System.Drawing.Point(24, 172);
+            this.lblDesc.Location = new System.Drawing.Point(30, 215);
+            this.lblDesc.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblDesc.Name = "lblDesc";
-            this.lblDesc.Size = new System.Drawing.Size(672, 454);
+            this.lblDesc.Size = new System.Drawing.Size(840, 568);
             this.lblDesc.TabIndex = 137;
             this.lblDesc.Text = "description";
             // 
@@ -322,29 +335,31 @@ namespace ThisIsWin11
             // 
             this.menuPresenter.BackColor = System.Drawing.Color.WhiteSmoke;
             this.menuPresenter.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.menuPresenter.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menuPresenter.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuPresenterInfo});
             this.menuPresenter.Name = "menuMain";
             this.menuPresenter.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.menuPresenter.Size = new System.Drawing.Size(118, 34);
+            this.menuPresenter.Size = new System.Drawing.Size(131, 40);
             // 
             // menuPresenterInfo
             // 
             this.menuPresenterInfo.Name = "menuPresenterInfo";
-            this.menuPresenterInfo.Size = new System.Drawing.Size(117, 30);
+            this.menuPresenterInfo.Size = new System.Drawing.Size(130, 36);
             this.menuPresenterInfo.Text = "Info";
             this.menuPresenterInfo.Click += new System.EventHandler(this.menuPresenterInfo_Click);
             // 
             // HomeWindow
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoScroll = true;
             this.BackColor = System.Drawing.Color.White;
-            this.ClientSize = new System.Drawing.Size(1087, 770);
+            this.ClientSize = new System.Drawing.Size(1359, 962);
             this.Controls.Add(this.pnlMiddle);
             this.Controls.Add(this.pnlLeft);
             this.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "HomeWindow";
             this.ShowIcon = false;
             this.Text = "Presenter";

--- a/src/TIW11/Pages/PackagesWindow.Designer.cs
+++ b/src/TIW11/Pages/PackagesWindow.Designer.cs
@@ -65,9 +65,10 @@ namespace ThisIsWin11
             this.lblHeader.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblHeader.ForeColor = System.Drawing.Color.DimGray;
             this.lblHeader.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblHeader.Location = new System.Drawing.Point(24, 19);
+            this.lblHeader.Location = new System.Drawing.Point(30, 24);
+            this.lblHeader.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeader.Name = "lblHeader";
-            this.lblHeader.Size = new System.Drawing.Size(188, 32);
+            this.lblHeader.Size = new System.Drawing.Size(236, 41);
             this.lblHeader.TabIndex = 139;
             this.lblHeader.Text = "Install packages";
             // 
@@ -79,10 +80,10 @@ namespace ThisIsWin11
             this.btnCreatePackage.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnCreatePackage.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnCreatePackage.ForeColor = System.Drawing.Color.Black;
-            this.btnCreatePackage.Location = new System.Drawing.Point(24, 24);
+            this.btnCreatePackage.Location = new System.Drawing.Point(30, 30);
             this.btnCreatePackage.Margin = new System.Windows.Forms.Padding(2);
             this.btnCreatePackage.Name = "btnCreatePackage";
-            this.btnCreatePackage.Size = new System.Drawing.Size(213, 30);
+            this.btnCreatePackage.Size = new System.Drawing.Size(266, 38);
             this.btnCreatePackage.TabIndex = 141;
             this.btnCreatePackage.Text = "1. Create Package";
             this.btnCreatePackage.UseVisualStyleBackColor = false;
@@ -96,10 +97,10 @@ namespace ThisIsWin11
             this.btnRunPackage.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnRunPackage.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnRunPackage.ForeColor = System.Drawing.Color.Black;
-            this.btnRunPackage.Location = new System.Drawing.Point(251, 24);
+            this.btnRunPackage.Location = new System.Drawing.Point(314, 30);
             this.btnRunPackage.Margin = new System.Windows.Forms.Padding(2);
             this.btnRunPackage.Name = "btnRunPackage";
-            this.btnRunPackage.Size = new System.Drawing.Size(213, 30);
+            this.btnRunPackage.Size = new System.Drawing.Size(266, 38);
             this.btnRunPackage.TabIndex = 142;
             this.btnRunPackage.Text = "2. Run Installer";
             this.btnRunPackage.UseVisualStyleBackColor = false;
@@ -112,10 +113,11 @@ namespace ThisIsWin11
             this.btnPackagesMenu.FlatAppearance.BorderSize = 0;
             this.btnPackagesMenu.FlatAppearance.MouseOverBackColor = System.Drawing.Color.LightGray;
             this.btnPackagesMenu.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnPackagesMenu.Font = new System.Drawing.Font("Segoe MDL2 Assets", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnPackagesMenu.Location = new System.Drawing.Point(667, 0);
+            this.btnPackagesMenu.Font = new System.Drawing.Font("Segoe Fluent Icons", 14.25F);
+            this.btnPackagesMenu.Location = new System.Drawing.Point(834, 0);
+            this.btnPackagesMenu.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnPackagesMenu.Name = "btnPackagesMenu";
-            this.btnPackagesMenu.Size = new System.Drawing.Size(48, 51);
+            this.btnPackagesMenu.Size = new System.Drawing.Size(60, 64);
             this.btnPackagesMenu.TabIndex = 157;
             this.btnPackagesMenu.UseVisualStyleBackColor = false;
             this.btnPackagesMenu.Click += new System.EventHandler(this.btnPackagesMenu_Click);
@@ -124,6 +126,7 @@ namespace ThisIsWin11
             // 
             this.menuPackages.BackColor = System.Drawing.Color.WhiteSmoke;
             this.menuPackages.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.menuPackages.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menuPackages.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuPackagesImport,
             this.menuPackagesExport,
@@ -134,33 +137,33 @@ namespace ThisIsWin11
             this.toolStripMenuItem1});
             this.menuPackages.Name = "menuMain";
             this.menuPackages.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.menuPackages.Size = new System.Drawing.Size(303, 190);
+            this.menuPackages.Size = new System.Drawing.Size(376, 226);
             // 
             // menuPackagesImport
             // 
             this.menuPackagesImport.Name = "menuPackagesImport";
-            this.menuPackagesImport.Size = new System.Drawing.Size(302, 30);
+            this.menuPackagesImport.Size = new System.Drawing.Size(375, 36);
             this.menuPackagesImport.Text = "Import package list";
             this.menuPackagesImport.Click += new System.EventHandler(this.menuPackagesImport_Click);
             // 
             // menuPackagesExport
             // 
             this.menuPackagesExport.Name = "menuPackagesExport";
-            this.menuPackagesExport.Size = new System.Drawing.Size(302, 30);
+            this.menuPackagesExport.Size = new System.Drawing.Size(375, 36);
             this.menuPackagesExport.Text = "Export to PowerShell";
             this.menuPackagesExport.Click += new System.EventHandler(this.menuPackagesExport_Click);
             // 
             // menuPackagesExpand
             // 
             this.menuPackagesExpand.Name = "menuPackagesExpand";
-            this.menuPackagesExpand.Size = new System.Drawing.Size(302, 30);
+            this.menuPackagesExpand.Size = new System.Drawing.Size(375, 36);
             this.menuPackagesExpand.Text = "Expand all";
             this.menuPackagesExpand.Click += new System.EventHandler(this.menuPackagesExpand_Click);
             // 
             // menuPackagesRefresh
             // 
             this.menuPackagesRefresh.Name = "menuPackagesRefresh";
-            this.menuPackagesRefresh.Size = new System.Drawing.Size(302, 30);
+            this.menuPackagesRefresh.Size = new System.Drawing.Size(375, 36);
             this.menuPackagesRefresh.Text = "Refresh";
             this.menuPackagesRefresh.Click += new System.EventHandler(this.menuPackagesRefresh_Click);
             // 
@@ -168,21 +171,21 @@ namespace ThisIsWin11
             // 
             this.menuPackagesPopOut.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.menuPackagesPopOut.Name = "menuPackagesPopOut";
-            this.menuPackagesPopOut.Size = new System.Drawing.Size(302, 30);
+            this.menuPackagesPopOut.Size = new System.Drawing.Size(375, 36);
             this.menuPackagesPopOut.Text = "Pop-out-App";
             this.menuPackagesPopOut.Click += new System.EventHandler(this.menuPackagesPopOut_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(299, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(372, 6);
             // 
             // toolStripMenuItem1
             // 
             this.toolStripMenuItem1.Enabled = false;
             this.toolStripMenuItem1.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(302, 30);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(375, 36);
             this.toolStripMenuItem1.Text = "Powered by Windows Package Manager";
             // 
             // btnInstallWinget
@@ -194,9 +197,10 @@ namespace ThisIsWin11
             this.btnInstallWinget.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnInstallWinget.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnInstallWinget.ForeColor = System.Drawing.Color.WhiteSmoke;
-            this.btnInstallWinget.Location = new System.Drawing.Point(27, 538);
+            this.btnInstallWinget.Location = new System.Drawing.Point(34, 672);
+            this.btnInstallWinget.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnInstallWinget.Name = "btnInstallWinget";
-            this.btnInstallWinget.Size = new System.Drawing.Size(225, 30);
+            this.btnInstallWinget.Size = new System.Drawing.Size(281, 38);
             this.btnInstallWinget.TabIndex = 161;
             this.btnInstallWinget.Text = "Install Windows Package Manager";
             this.btnInstallWinget.UseVisualStyleBackColor = false;
@@ -206,10 +210,11 @@ namespace ThisIsWin11
             // 
             this.progress.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progress.Location = new System.Drawing.Point(24, 78);
+            this.progress.Location = new System.Drawing.Point(30, 98);
+            this.progress.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.progress.MarqueeAnimationSpeed = 30;
             this.progress.Name = "progress";
-            this.progress.Size = new System.Drawing.Size(669, 5);
+            this.progress.Size = new System.Drawing.Size(836, 6);
             this.progress.TabIndex = 162;
             this.progress.Visible = false;
             // 
@@ -221,9 +226,10 @@ namespace ThisIsWin11
             this.pnlRight.Controls.Add(this.btnInstallWinget);
             this.pnlRight.Controls.Add(this.rtbPS);
             this.pnlRight.Dock = System.Windows.Forms.DockStyle.Right;
-            this.pnlRight.Location = new System.Drawing.Point(716, 0);
+            this.pnlRight.Location = new System.Drawing.Point(895, 0);
+            this.pnlRight.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pnlRight.Name = "pnlRight";
-            this.pnlRight.Size = new System.Drawing.Size(371, 770);
+            this.pnlRight.Size = new System.Drawing.Size(464, 962);
             this.pnlRight.TabIndex = 163;
             // 
             // lblModuleInfo
@@ -232,9 +238,10 @@ namespace ThisIsWin11
             this.lblModuleInfo.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblModuleInfo.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lblModuleInfo.LinkColor = System.Drawing.Color.MediumVioletRed;
-            this.lblModuleInfo.Location = new System.Drawing.Point(24, 59);
+            this.lblModuleInfo.Location = new System.Drawing.Point(30, 74);
+            this.lblModuleInfo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblModuleInfo.Name = "lblModuleInfo";
-            this.lblModuleInfo.Size = new System.Drawing.Size(320, 17);
+            this.lblModuleInfo.Size = new System.Drawing.Size(400, 21);
             this.lblModuleInfo.TabIndex = 162;
             this.lblModuleInfo.TabStop = true;
             this.lblModuleInfo.Text = "Learn more about Packages";
@@ -249,9 +256,10 @@ namespace ThisIsWin11
             this.lblModuleName.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblModuleName.ForeColor = System.Drawing.Color.Black;
             this.lblModuleName.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblModuleName.Location = new System.Drawing.Point(21, 21);
+            this.lblModuleName.Location = new System.Drawing.Point(26, 26);
+            this.lblModuleName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblModuleName.Name = "lblModuleName";
-            this.lblModuleName.Size = new System.Drawing.Size(323, 32);
+            this.lblModuleName.Size = new System.Drawing.Size(404, 40);
             this.lblModuleName.TabIndex = 135;
             this.lblModuleName.Text = "Packages";
             // 
@@ -264,10 +272,11 @@ namespace ThisIsWin11
             this.rtbPS.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.rtbPS.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.rtbPS.HideSelection = false;
-            this.rtbPS.Location = new System.Drawing.Point(27, 110);
+            this.rtbPS.Location = new System.Drawing.Point(34, 138);
+            this.rtbPS.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.rtbPS.Name = "rtbPS";
             this.rtbPS.ReadOnly = true;
-            this.rtbPS.Size = new System.Drawing.Size(343, 644);
+            this.rtbPS.Size = new System.Drawing.Size(429, 805);
             this.rtbPS.TabIndex = 138;
             this.rtbPS.Text = "";
             this.rtbPS.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.rtbPS_LinkClicked);
@@ -278,9 +287,10 @@ namespace ThisIsWin11
             this.pnlBottom.Controls.Add(this.btnCreatePackage);
             this.pnlBottom.Controls.Add(this.btnRunPackage);
             this.pnlBottom.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.pnlBottom.Location = new System.Drawing.Point(0, 697);
+            this.pnlBottom.Location = new System.Drawing.Point(0, 871);
+            this.pnlBottom.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pnlBottom.Name = "pnlBottom";
-            this.pnlBottom.Size = new System.Drawing.Size(716, 73);
+            this.pnlBottom.Size = new System.Drawing.Size(895, 91);
             this.pnlBottom.TabIndex = 164;
             // 
             // tvwPackages
@@ -292,19 +302,20 @@ namespace ThisIsWin11
             this.tvwPackages.CheckBoxes = true;
             this.tvwPackages.Font = new System.Drawing.Font("Segoe UI Semilight", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.tvwPackages.HotTracking = true;
-            this.tvwPackages.Location = new System.Drawing.Point(24, 97);
+            this.tvwPackages.Location = new System.Drawing.Point(30, 121);
+            this.tvwPackages.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tvwPackages.Name = "tvwPackages";
             this.tvwPackages.ShowLines = false;
-            this.tvwPackages.Size = new System.Drawing.Size(692, 600);
+            this.tvwPackages.Size = new System.Drawing.Size(865, 750);
             this.tvwPackages.TabIndex = 165;
             // 
             // PackagesWindow
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoScroll = true;
             this.BackColor = System.Drawing.Color.White;
-            this.ClientSize = new System.Drawing.Size(1087, 770);
+            this.ClientSize = new System.Drawing.Size(1359, 962);
             this.Controls.Add(this.tvwPackages);
             this.Controls.Add(this.pnlBottom);
             this.Controls.Add(this.progress);
@@ -312,6 +323,7 @@ namespace ThisIsWin11
             this.Controls.Add(this.lblHeader);
             this.Controls.Add(this.pnlRight);
             this.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "PackagesWindow";
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/src/TIW11/Pages/SystemWindow.Designer.cs
+++ b/src/TIW11/Pages/SystemWindow.Designer.cs
@@ -65,10 +65,11 @@ namespace ThisIsWin11
             this.btnSystemMenu.FlatAppearance.BorderSize = 0;
             this.btnSystemMenu.FlatAppearance.MouseOverBackColor = System.Drawing.Color.LightGray;
             this.btnSystemMenu.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnSystemMenu.Font = new System.Drawing.Font("Segoe MDL2 Assets", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnSystemMenu.Location = new System.Drawing.Point(667, 0);
+            this.btnSystemMenu.Font = new System.Drawing.Font("Segoe Fluent Icons", 14.25F);
+            this.btnSystemMenu.Location = new System.Drawing.Point(834, 0);
+            this.btnSystemMenu.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnSystemMenu.Name = "btnSystemMenu";
-            this.btnSystemMenu.Size = new System.Drawing.Size(48, 51);
+            this.btnSystemMenu.Size = new System.Drawing.Size(60, 64);
             this.btnSystemMenu.TabIndex = 162;
             this.btnSystemMenu.UseVisualStyleBackColor = false;
             this.btnSystemMenu.Click += new System.EventHandler(this.btnSystemMenu_Click);
@@ -82,9 +83,10 @@ namespace ThisIsWin11
             this.lblHeader.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblHeader.ForeColor = System.Drawing.Color.DimGray;
             this.lblHeader.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblHeader.Location = new System.Drawing.Point(24, 19);
+            this.lblHeader.Location = new System.Drawing.Point(30, 24);
+            this.lblHeader.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHeader.Name = "lblHeader";
-            this.lblHeader.Size = new System.Drawing.Size(669, 32);
+            this.lblHeader.Size = new System.Drawing.Size(836, 40);
             this.lblHeader.TabIndex = 161;
             this.lblHeader.Text = "Change settings";
             // 
@@ -96,10 +98,10 @@ namespace ThisIsWin11
             this.btnSystemCheck.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnSystemCheck.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnSystemCheck.ForeColor = System.Drawing.Color.Black;
-            this.btnSystemCheck.Location = new System.Drawing.Point(24, 24);
+            this.btnSystemCheck.Location = new System.Drawing.Point(30, 30);
             this.btnSystemCheck.Margin = new System.Windows.Forms.Padding(2);
             this.btnSystemCheck.Name = "btnSystemCheck";
-            this.btnSystemCheck.Size = new System.Drawing.Size(213, 30);
+            this.btnSystemCheck.Size = new System.Drawing.Size(266, 38);
             this.btnSystemCheck.TabIndex = 159;
             this.btnSystemCheck.Text = "Check";
             this.btnSystemCheck.UseVisualStyleBackColor = false;
@@ -109,6 +111,7 @@ namespace ThisIsWin11
             // 
             this.menuSystem.BackColor = System.Drawing.Color.WhiteSmoke;
             this.menuSystem.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.menuSystem.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menuSystem.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuSystemImportProfile,
             this.menuSystemExportProfile,
@@ -119,33 +122,33 @@ namespace ThisIsWin11
             this.menuSystemVersioning});
             this.menuSystem.Name = "menuMain";
             this.menuSystem.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.menuSystem.Size = new System.Drawing.Size(201, 190);
+            this.menuSystem.Size = new System.Drawing.Size(236, 226);
             // 
             // menuSystemImportProfile
             // 
             this.menuSystemImportProfile.Name = "menuSystemImportProfile";
-            this.menuSystemImportProfile.Size = new System.Drawing.Size(200, 30);
+            this.menuSystemImportProfile.Size = new System.Drawing.Size(235, 36);
             this.menuSystemImportProfile.Text = "Import profile";
             this.menuSystemImportProfile.Click += new System.EventHandler(this.menuSystemImportProfile_Click);
             // 
             // menuSystemExportProfile
             // 
             this.menuSystemExportProfile.Name = "menuSystemExportProfile";
-            this.menuSystemExportProfile.Size = new System.Drawing.Size(200, 30);
+            this.menuSystemExportProfile.Size = new System.Drawing.Size(235, 36);
             this.menuSystemExportProfile.Text = "Export profile";
             this.menuSystemExportProfile.Click += new System.EventHandler(this.menuSystemExportProfile_Click);
             // 
             // menuSystemExportLog
             // 
             this.menuSystemExportLog.Name = "menuSystemExportLog";
-            this.menuSystemExportLog.Size = new System.Drawing.Size(200, 30);
+            this.menuSystemExportLog.Size = new System.Drawing.Size(235, 36);
             this.menuSystemExportLog.Text = "Export log";
             this.menuSystemExportLog.Click += new System.EventHandler(this.menuSystemExportLog_Click);
             // 
             // menuSystemSelect
             // 
             this.menuSystemSelect.Name = "menuSystemSelect";
-            this.menuSystemSelect.Size = new System.Drawing.Size(200, 30);
+            this.menuSystemSelect.Size = new System.Drawing.Size(235, 36);
             this.menuSystemSelect.Text = "Select all";
             this.menuSystemSelect.Click += new System.EventHandler(this.menuSystemSelect_Click);
             // 
@@ -153,19 +156,19 @@ namespace ThisIsWin11
             // 
             this.menuSystemPopOut.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.menuSystemPopOut.Name = "menuSystemPopOut";
-            this.menuSystemPopOut.Size = new System.Drawing.Size(200, 30);
+            this.menuSystemPopOut.Size = new System.Drawing.Size(235, 36);
             this.menuSystemPopOut.Text = "Pop-out-App";
             this.menuSystemPopOut.Click += new System.EventHandler(this.menuSystemPopOut_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(197, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(232, 6);
             // 
             // menuSystemVersioning
             // 
             this.menuSystemVersioning.Name = "menuSystemVersioning";
-            this.menuSystemVersioning.Size = new System.Drawing.Size(200, 30);
+            this.menuSystemVersioning.Size = new System.Drawing.Size(235, 36);
             this.menuSystemVersioning.Text = "Info";
             this.menuSystemVersioning.Click += new System.EventHandler(this.menuSystemInfo_Click);
             // 
@@ -173,9 +176,10 @@ namespace ThisIsWin11
             // 
             this.progress.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progress.Location = new System.Drawing.Point(30, 78);
+            this.progress.Location = new System.Drawing.Point(38, 98);
+            this.progress.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.progress.Name = "progress";
-            this.progress.Size = new System.Drawing.Size(663, 5);
+            this.progress.Size = new System.Drawing.Size(829, 6);
             this.progress.TabIndex = 166;
             this.progress.Visible = false;
             // 
@@ -190,11 +194,12 @@ namespace ThisIsWin11
             this.tvwAssessments.Font = new System.Drawing.Font("Segoe UI Semilight", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.tvwAssessments.HideSelection = false;
             this.tvwAssessments.HotTracking = true;
-            this.tvwAssessments.Location = new System.Drawing.Point(24, 99);
+            this.tvwAssessments.Location = new System.Drawing.Point(30, 124);
+            this.tvwAssessments.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tvwAssessments.Name = "tvwAssessments";
             this.tvwAssessments.ShowLines = false;
             this.tvwAssessments.ShowNodeToolTips = true;
-            this.tvwAssessments.Size = new System.Drawing.Size(691, 589);
+            this.tvwAssessments.Size = new System.Drawing.Size(864, 736);
             this.tvwAssessments.TabIndex = 168;
             this.tvwAssessments.AfterCheck += new System.Windows.Forms.TreeViewEventHandler(this.tvwAssessments_AfterCheck);
             this.tvwAssessments.Click += new System.EventHandler(this.tvwAssessments_Click);
@@ -207,10 +212,10 @@ namespace ThisIsWin11
             this.btnSystemFix.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnSystemFix.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnSystemFix.ForeColor = System.Drawing.Color.Black;
-            this.btnSystemFix.Location = new System.Drawing.Point(251, 24);
+            this.btnSystemFix.Location = new System.Drawing.Point(314, 30);
             this.btnSystemFix.Margin = new System.Windows.Forms.Padding(2);
             this.btnSystemFix.Name = "btnSystemFix";
-            this.btnSystemFix.Size = new System.Drawing.Size(213, 30);
+            this.btnSystemFix.Size = new System.Drawing.Size(266, 38);
             this.btnSystemFix.TabIndex = 167;
             this.btnSystemFix.Text = "Fix issues";
             this.btnSystemFix.UseVisualStyleBackColor = false;
@@ -223,9 +228,10 @@ namespace ThisIsWin11
             this.pnlRight.Controls.Add(this.lblModuleName);
             this.pnlRight.Controls.Add(this.rtbPS);
             this.pnlRight.Dock = System.Windows.Forms.DockStyle.Right;
-            this.pnlRight.Location = new System.Drawing.Point(716, 0);
+            this.pnlRight.Location = new System.Drawing.Point(895, 0);
+            this.pnlRight.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pnlRight.Name = "pnlRight";
-            this.pnlRight.Size = new System.Drawing.Size(371, 770);
+            this.pnlRight.Size = new System.Drawing.Size(464, 962);
             this.pnlRight.TabIndex = 170;
             // 
             // lblModuleInfo
@@ -234,9 +240,10 @@ namespace ThisIsWin11
             this.lblModuleInfo.Font = new System.Drawing.Font("Segoe UI Semibold", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblModuleInfo.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lblModuleInfo.LinkColor = System.Drawing.Color.MediumVioletRed;
-            this.lblModuleInfo.Location = new System.Drawing.Point(24, 59);
+            this.lblModuleInfo.Location = new System.Drawing.Point(30, 74);
+            this.lblModuleInfo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblModuleInfo.Name = "lblModuleInfo";
-            this.lblModuleInfo.Size = new System.Drawing.Size(320, 17);
+            this.lblModuleInfo.Size = new System.Drawing.Size(400, 21);
             this.lblModuleInfo.TabIndex = 161;
             this.lblModuleInfo.TabStop = true;
             this.lblModuleInfo.Text = "Learn more about OpenTweaks";
@@ -251,9 +258,10 @@ namespace ThisIsWin11
             this.lblModuleName.Font = new System.Drawing.Font("Segoe UI Semibold", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblModuleName.ForeColor = System.Drawing.Color.Black;
             this.lblModuleName.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.lblModuleName.Location = new System.Drawing.Point(21, 21);
+            this.lblModuleName.Location = new System.Drawing.Point(26, 26);
+            this.lblModuleName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblModuleName.Name = "lblModuleName";
-            this.lblModuleName.Size = new System.Drawing.Size(323, 32);
+            this.lblModuleName.Size = new System.Drawing.Size(404, 40);
             this.lblModuleName.TabIndex = 135;
             this.lblModuleName.Text = "OpenTweaks";
             // 
@@ -265,10 +273,11 @@ namespace ThisIsWin11
             this.rtbPS.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.rtbPS.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.rtbPS.HideSelection = false;
-            this.rtbPS.Location = new System.Drawing.Point(27, 110);
+            this.rtbPS.Location = new System.Drawing.Point(34, 138);
+            this.rtbPS.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.rtbPS.Name = "rtbPS";
             this.rtbPS.ReadOnly = true;
-            this.rtbPS.Size = new System.Drawing.Size(343, 644);
+            this.rtbPS.Size = new System.Drawing.Size(429, 805);
             this.rtbPS.TabIndex = 138;
             this.rtbPS.Text = "";
             this.rtbPS.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.rtbPS_LinkClicked);
@@ -284,9 +293,10 @@ namespace ThisIsWin11
             this.lnkSubHeader.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.lnkSubHeader.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkSubHeader.LinkColor = System.Drawing.Color.MediumVioletRed;
-            this.lnkSubHeader.Location = new System.Drawing.Point(28, 57);
+            this.lnkSubHeader.Location = new System.Drawing.Point(35, 71);
+            this.lnkSubHeader.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lnkSubHeader.Name = "lnkSubHeader";
-            this.lnkSubHeader.Size = new System.Drawing.Size(665, 18);
+            this.lnkSubHeader.Size = new System.Drawing.Size(831, 22);
             this.lnkSubHeader.TabIndex = 171;
             this.lnkSubHeader.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkSubHeader_LinkClicked);
             // 
@@ -299,9 +309,10 @@ namespace ThisIsWin11
             this.lnkSystemPreset.Font = new System.Drawing.Font("Segoe UI Semilight", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lnkSystemPreset.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
             this.lnkSystemPreset.LinkColor = System.Drawing.Color.DimGray;
-            this.lnkSystemPreset.Location = new System.Drawing.Point(92, 364);
+            this.lnkSystemPreset.Location = new System.Drawing.Point(115, 455);
+            this.lnkSystemPreset.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lnkSystemPreset.Name = "lnkSystemPreset";
-            this.lnkSystemPreset.Size = new System.Drawing.Size(580, 30);
+            this.lnkSystemPreset.Size = new System.Drawing.Size(725, 38);
             this.lnkSystemPreset.TabIndex = 172;
             this.lnkSystemPreset.TabStop = true;
             this.lnkSystemPreset.Text = "Click here to load a preset and let Windows 11 look and feel like Windows 10";
@@ -314,10 +325,11 @@ namespace ThisIsWin11
             this.btnSystemUndo.FlatAppearance.BorderSize = 0;
             this.btnSystemUndo.FlatAppearance.MouseOverBackColor = System.Drawing.Color.HotPink;
             this.btnSystemUndo.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnSystemUndo.Font = new System.Drawing.Font("Segoe MDL2 Assets", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnSystemUndo.Location = new System.Drawing.Point(604, 0);
+            this.btnSystemUndo.Font = new System.Drawing.Font("Segoe Fluent Icons", 14.25F);
+            this.btnSystemUndo.Location = new System.Drawing.Point(755, 0);
+            this.btnSystemUndo.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnSystemUndo.Name = "btnSystemUndo";
-            this.btnSystemUndo.Size = new System.Drawing.Size(48, 51);
+            this.btnSystemUndo.Size = new System.Drawing.Size(60, 64);
             this.btnSystemUndo.TabIndex = 174;
             this.tt.SetToolTip(this.btnSystemUndo, "Restore default Windows 11 settings");
             this.btnSystemUndo.UseVisualStyleBackColor = false;
@@ -338,18 +350,19 @@ namespace ThisIsWin11
             this.pnlBottom.Controls.Add(this.btnSystemFix);
             this.pnlBottom.Controls.Add(this.btnSystemCheck);
             this.pnlBottom.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.pnlBottom.Location = new System.Drawing.Point(0, 694);
+            this.pnlBottom.Location = new System.Drawing.Point(0, 867);
+            this.pnlBottom.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.pnlBottom.Name = "pnlBottom";
-            this.pnlBottom.Size = new System.Drawing.Size(716, 76);
+            this.pnlBottom.Size = new System.Drawing.Size(895, 95);
             this.pnlBottom.TabIndex = 175;
             // 
             // SystemWindow
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoScroll = true;
             this.BackColor = System.Drawing.Color.White;
-            this.ClientSize = new System.Drawing.Size(1087, 770);
+            this.ClientSize = new System.Drawing.Size(1359, 962);
             this.Controls.Add(this.pnlBottom);
             this.Controls.Add(this.btnSystemUndo);
             this.Controls.Add(this.lnkSystemPreset);
@@ -360,6 +373,7 @@ namespace ThisIsWin11
             this.Controls.Add(this.lblHeader);
             this.Controls.Add(this.pnlRight);
             this.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "SystemWindow";
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;


### PR DESCRIPTION
With the release of Windows 11, Microsoft has replaced Segoe MDL2 Assets with Segoe Fluent Icons as the recommended symbol icon font.

Source: https://docs.microsoft.com/en-us/windows/apps/design/style/segoe-fluent-icons-font
