### PR TITLE
Titlebar matches Windows now and has Mica behind it

### DIFF
--- a/src/TIW11/MainWindow.cs
+++ b/src/TIW11/MainWindow.cs
@@ -1,8 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using System.Runtime.InteropServices;
+using Microsoft.Win32;
 
 namespace ThisIsWin11
 {
@@ -13,9 +15,19 @@ namespace ThisIsWin11
 
         private bool isGlobalNavOpen = false;
 
+        [DllImport("DwmApi")]
+        private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, int[] attrValue, int attrSize);
+
         public MainWindow()
         {
             InitializeComponent();
+
+            int lightmode = (int)Registry.GetValue(@"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize", "AppsUseLightTheme", "1");
+            if (lightmode != 1)
+            {
+                if (DwmSetWindowAttribute(Handle, 19, new[] { 1 }, 4) != 0)
+                    DwmSetWindowAttribute(Handle, 20, new[] { 1 }, 4);
+            }
 
             this.MinimumSize = new Size(810, 755);
 


### PR DESCRIPTION
This PR Implements a messy way to get a dark titlebar when Windows 11 is set to dark mode and it sets itself to light when it's not. In addition, it also adds Mica behind the titlebar, both in light and darkmode. Changing the titlebar color requires restarting the app to take effect, just like the rest of the UI does.

Fixes one of the requests I have in #174

Example:
![image](https://user-images.githubusercontent.com/108924641/185811832-34a209ed-6dd3-45ac-a8d2-9348a23fe918.png)
![image](https://user-images.githubusercontent.com/108924641/185811817-f496d393-0c14-45e3-b9d4-729c94f4e6b4.png)

I'm very sorry for the poor formatting and code quality overall, it might need to be refactored.